### PR TITLE
Fix runtime error under python 3.x

### DIFF
--- a/proxysql-nagios
+++ b/proxysql-nagios
@@ -256,7 +256,7 @@ def prules_check(pconn, nagioslogger, args):
     doutput_values = pcursor.fetchall()
     pconn.close()
 
-    if hashlib.md5(str(routput_values)).hexdigest() == hashlib.md5(str(doutput_values)).hexdigest():
+    if hashlib.md5(str(routput_values).encode()).hexdigest() == hashlib.md5(str(doutput_values).encode()).hexdigest():
         nagioslogger.info('ProxySQL Query Rules: DISK / RUNTIME config matches')
         sys.exit(OK)
     else:


### PR DESCRIPTION
The existing test is only compatible with python 2.x (which has been [deprecated](https://docs.datarobot.com/en/docs/release/deprecations-and-migrations/python2.html)).  Under python 3.x, you receive the following error:

```
% ./proxysql-nagios -d ~/test.cnf -H 127.0.0.1 -p 6032 -t rules --runtime
CRITICAL - ProxySQL check failed: Strings must be encoded before hashing
```

Calling encode() on the string before passing it to hashlib's md5() addresses this issue.